### PR TITLE
Add alternative to contentful

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Here are some of the most important websites that I use on a daily basis:
 
 ## Open Source alternatives to XXX
 
+- [payload](https://payloadcms.com/) - contentful
 - [supabase.com](http://supabase.com) - firebase
 - [documenso.com](http://documenso.com) - docu sign
 - [cal.com](http://cal.com) - calendly


### PR DESCRIPTION
Payload is a fully open source and technologically superior alternative to contentful, a closed source headless cms.