### PR TITLE
added Firecamp to the alternative list

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Here are some of the most important websites that I use on a daily basis:
 - [sentry.io](https://sentry.io) - error tracking
 - [n8n.io](https://n8n.io) - zappier
 - [appsmith.com](https://appsmith.com) - retool
+- [firecamp.io](https://firecamp.io/) - postman
 - [clickhouse.com](https://clickhouse.com) - bigquery
 - [gitlab.com](https://gitlab.com) - github
 - [penpot.app](https://penpot.app) - figma


### PR DESCRIPTION
Firecamp is opensource postman alternative. 
